### PR TITLE
Adds inverse behaviour: remove colours from rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ var colorsOnly = require('postcss-colors-only');
 var options = {
   withoutGrey: false, // set to true to remove rules that only have grey colors
   withoutMonochrome: false, // set to true to remove rules that only have grey, black, or white colors
+  inverse: false, // set to true to remove colors from rules
 };
 
 postcss()

--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ module.exports = postcss.plugin('postcss-colors-only', function (options) {
             'text-shadow'
         ];
 
-        if (blacklist.some(function (regexp) {
+        if (blacklist.some(function (blacklistItem) {
             return ['value', 'prop'].some(function (key) {
-                return decl[key].indexOf(regexp) !== -1;
+                return decl[key].indexOf(blacklistItem) !== -1;
             });
         })) {
             return;

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = postcss.plugin('postcss-colors-only', function (options) {
         if (colors.length) {
             decl.value = colors.reduce(function (value, color) {
                 return value.replace(color, '');
-            }, decl.value);
+            }, decl.value).trim();
         }
 
         if (decl.value.length === 0) {

--- a/test/test.js
+++ b/test/test.js
@@ -749,7 +749,7 @@ describe('postcss-colors-only with inverse flag enabled', function () {
 
     it('should remove empty rules', function (done) {
         test(
-            'p { border: 1px solid red; color: blue;  }',
+            'p { border: 1px solid red; color: blue; }',
             'p { border: 1px solid; }',
             opts,
             done

--- a/test/test.js
+++ b/test/test.js
@@ -749,7 +749,7 @@ describe('postcss-colors-only with inverse flag enabled', function () {
 
     it('should remove empty rules', function (done) {
         test(
-            'p { border: 1px solid red; color: blue; }',
+            'p { border: 1px solid red; color: blue;  }',
             'p { border: 1px solid; }',
             opts,
             done

--- a/test/test.js
+++ b/test/test.js
@@ -747,4 +747,13 @@ describe('postcss-colors-only with inverse flag enabled', function () {
         );
     });
 
+    it('should remove empty rules', function (done) {
+        test(
+            'p { border: 1px solid red; color: blue; }',
+            'p { border: 1px solid; }',
+            opts,
+            done
+        );
+    });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -737,4 +737,14 @@ describe('postcss-colors-only with inverse flag enabled', function () {
             done
         );
     });
+
+    it('should remove colors from shorthand rules', function (done) {
+        test(
+            'p { border: 1px solid red; }',
+            'p { border: 1px solid; }',
+            opts,
+            done
+        );
+    });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -550,3 +550,191 @@ describe('postcss-colors-only', function () {
         );
     });
 });
+
+describe('postcss-colors-only with inverse flag enabled', function () {
+
+    var opts = { inverse: true };
+
+    it('should remove named color.', function (done) {
+        test(
+            'a { color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove three-letter hex color.', function (done) {
+        test(
+            'a { color: #123; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove six-letter hex color.', function (done) {
+        test(
+            'a { color: #123123; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove rgb color.', function (done) {
+        test(
+            'a { color: rgb(1, 2, 3); } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove rgba color.', function (done) {
+        test(
+            'a { color: rgba(1, 2, 3, 0.5); } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove hsl color.', function (done) {
+        test(
+            'a { color: hsl(1, 2%, 3%); } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove hsla color.', function (done) {
+        test(
+            'a { color: hsla(1, 2%, 3%, 0.5); } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove background-color.', function (done) {
+        test(
+            'a { background-color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove border-color.', function (done) {
+        test(
+            'a { border-color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove border-top-color.', function (done) {
+        test(
+            'a { border-top-color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove border-right-color.', function (done) {
+        test(
+            'a { border-right-color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove border-bottom-color.', function (done) {
+        test(
+            'a { border-bottom-color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove border-left-color.', function (done) {
+        test(
+            'a { border-left-color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should keep background-image.', function (done) {
+        test(
+            'a { background-image: linear-gradient(to bottom, red, blue); } ' +
+                'p { display: block; }',
+            'a { background-image: linear-gradient(to bottom, red, blue); } ' +
+                'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove outline-color.', function (done) {
+        test(
+            'a { outline-color: red; } p { display: block; }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should keep text-shadow.', function (done) {
+        test(
+            'a { text-shadow: 1px 1px 2px black; } p { display: block; }',
+            'a { text-shadow: 1px 1px 2px black; } p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove comment', function (done) {
+        test(
+            'a { color: red; } p { display: block; } /* some comment */',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should read nested @media rules', function (done) {
+        test(
+            'a { color: red; } @media (screen-only) { a { color: blue; } ' +
+                'p { display: block; } }',
+            '@media (screen-only) { p { display: block; } }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove empty @media rule', function (done) {
+        test(
+            'p { display: block; } @media (screen-only) { a { color: blue; } }',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+
+    it('should remove non-media atrule', function (done) {
+        test(
+            'a { color: red; } p { display: block; } @charset "UTF-8";',
+            'p { display: block; }',
+            opts,
+            done
+        );
+    });
+});


### PR DESCRIPTION
This pull request adds the possibility to get an inverse behaviour as removing colours from rules. Now you are able to split your existing CSS files as colour theme and layout.
